### PR TITLE
ops-5171-ionos-k8s-version

### DIFF
--- a/modules/ionos-k8s-cluster/README.md
+++ b/modules/ionos-k8s-cluster/README.md
@@ -39,6 +39,8 @@ No modules.
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | n/a |
 | <a name="output_cluster_k8s_version"></a> [cluster\_k8s\_version](#output\_cluster\_k8s\_version) | n/a |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | n/a |
+| <a name="output_nodepool_zone1_id"></a> [nodepool\_zone1\_id](#output\_nodepool\_zone1\_id) | n/a |
+| <a name="output_nodepool_zone2_id"></a> [nodepool\_zone2\_id](#output\_nodepool\_zone2\_id) | n/a |
 ## Requirements
 
 | Name | Version |

--- a/modules/ionos-k8s-cluster/output.tf
+++ b/modules/ionos-k8s-cluster/output.tf
@@ -8,8 +8,8 @@ output "cluster_id" {
   value = ionoscloud_k8s_cluster.cluster.id
 }
 output "nodepool_zone1_id" {
-  value = ionoscloud_k8s_node_pool.nodepool_zone1[0].id
+  value = ionoscloud_k8s_node_pool.nodepool_zone1[*].id
 }
 output "nodepool_zone2_id" {
-  value = ionoscloud_k8s_node_pool.nodepool_zone2[0].id
+  value = ionoscloud_k8s_node_pool.nodepool_zone2[*].id
 }

--- a/modules/ionos-k8s-cluster/output.tf
+++ b/modules/ionos-k8s-cluster/output.tf
@@ -7,3 +7,9 @@ output "cluster_k8s_version" {
 output "cluster_id" {
   value = ionoscloud_k8s_cluster.cluster.id
 }
+output "nodepool_zone1_id" {
+  value = ionoscloud_k8s_node_pool.nodepool_zone1[0].id
+}
+output "nodepool_zone2_id" {
+  value = ionoscloud_k8s_node_pool.nodepool_zone2[0].id
+}


### PR DESCRIPTION
# Description
In order to delete the node pool properly, we need to retrieve the Nodepool ID from Terraform output. I made some changes in ionos-k8s-cluster so that I can have the Nodepool ID as output.

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.