### PR TITLE
OPS-5165-fix-dependency-problem-lans

### DIFF
--- a/modules/ionos-datacenter/locals.tf
+++ b/modules/ionos-datacenter/locals.tf
@@ -25,9 +25,9 @@ locals {
   #     ]),
   # })
   # if no routes_map is provided, a default value of [{}] is given (just empty), to comply with type requirements in further processing
-  lan_service = flatten([ for id in ionoscloud_lan.service_lan.*.id: { id = id, routes_list = lookup(local.routes_map, id , [{}]) }])
+  lan_service = flatten([ for id in ionoscloud_lan.service_lan.*.id: { id = id, routes_list = [{}] }])
   lan_backend = flatten([ for id in ionoscloud_lan.backend_lan.*.id: { id = id, routes_list = lookup(local.routes_map, id , [{}]) }])
   lan_frontend = flatten([ for id in ionoscloud_lan.frontend_lan.*.id: { id = id, routes_list = lookup(local.routes_map, id , [{}]) }])
-  lan_nfs_server = flatten([ for id in ionoscloud_lan.nfs_server_lan.*.id: { id = id, routes_list = lookup(local.routes_map, id , [{}]) }])
-  lan_postgres = flatten([ for id in ionoscloud_lan.postgres_lan.*.id: { id = id, routes_list = lookup(local.routes_map, id , [{}]) }])
+  lan_nfs_server = flatten([ for id in ionoscloud_lan.nfs_server_lan.*.id: { id = id, routes_list = [{}] }])
+  lan_postgres = flatten([ for id in ionoscloud_lan.postgres_lan.*.id: { id = id, routes_list = [{}] }])
 }


### PR DESCRIPTION
# Description
remove lookup on lans that do not have any routes. This is meant to fix a dependency problem when adding a lan that should also get connected to the k8s cluster

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.