### PR TITLE
DBP-346-fix-ips-of-spsh-alb

### DIFF
--- a/modules/ionos-cidr-workaround/locals.tf
+++ b/modules/ionos-cidr-workaround/locals.tf
@@ -1,5 +1,5 @@
 locals {
   nicIndex = index(data.ionoscloud_servers.k8s_node.servers[0].nics.*.lan, tonumber(var.lan_id))
   prefix   = format("%s/24", data.ionoscloud_servers.k8s_node.servers[0].nics[local.nicIndex].ips[0])
-  node_lan_ips = flatten(data.ionoscloud_servers.k8s_nodes[*].servers[*].nics[local.nicIndex].ips[0])
+  node_lan_ips = flatten([for server_idx, server in data.ionoscloud_servers.k8s_nodes[*].servers[*] : [ for nic in flatten(server[*].nics[*]) :  nic.ips if nic.lan == tonumber(var.lan_id) ]])
 }

--- a/modules/ionos-cidr-workaround/locals.tf
+++ b/modules/ionos-cidr-workaround/locals.tf
@@ -1,5 +1,7 @@
 locals {
   nicIndex = index(data.ionoscloud_servers.k8s_node.servers[0].nics.*.lan, tonumber(var.lan_id))
   prefix   = format("%s/24", data.ionoscloud_servers.k8s_node.servers[0].nics[local.nicIndex].ips[0])
-  node_lan_ips = flatten([for server_idx, server in data.ionoscloud_servers.k8s_nodes[*].servers[*] : [ for nic in flatten(server[*].nics[*]) :  nic.ips if nic.lan == tonumber(var.lan_id) ]])
+  node_servers = data.ionoscloud_servers.k8s_nodes[*].servers[*]
+  # it gets a list of all the nics that are attached to the provided servers and extracts the ips as a list of only the nics, that are conneted via the provided lan
+  node_lan_ips = flatten([for server_idx, server in local.node_servers : [ for nic in flatten(server[*].nics[*]) :  nic.ips if nic.lan == tonumber(var.lan_id) ]])
 }


### PR DESCRIPTION
# Description
Change how node_lan_ips are generated. In the past it assumed that the nics are always in the same order. This makes problems when the order of nics on the node pools is different, so that the nic for one lan has indix 1 on one node pool and 2 on the other node pool. This fixes the problems and extracts all the ips associated with a certain lan id. 

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.