### PR TITLE
OPS-6085-option-for-multiple-named-lans

### DIFF
--- a/modules/ionos-datacenter/README.md
+++ b/modules/ionos-datacenter/README.md
@@ -26,6 +26,7 @@ No modules.
 | <a name="input_create_public_lan"></a> [create\_public\_lan](#input\_create\_public\_lan) | Specifies whether a public lan shall be created. Default: false. | `bool` | `false` | no |
 | <a name="input_create_service_crossconnect"></a> [create\_service\_crossconnect](#input\_create\_service\_crossconnect) | Specifies whether crossconnect shall be created. Default: false. | `bool` | `false` | no |
 | <a name="input_crossconnect_shared_group_ids"></a> [crossconnect\_shared\_group\_ids](#input\_crossconnect\_shared\_group\_ids) | Specifies which groups crossconnect shall be shared with. Default: []. | `list(string)` | `[]` | no |
+| <a name="input_custom_lans_to_create"></a> [custom\_lans\_to\_create](#input\_custom\_lans\_to\_create) | Map of for private LANs to be created. The key is used for the output. The value is used for the name: <datacenter name>-<value> | `map(string)` | `{}` | no |
 | <a name="input_datacenter_location"></a> [datacenter\_location](#input\_datacenter\_location) | n/a | `string` | `"de/txl"` | no |
 | <a name="input_datacenter_shares"></a> [datacenter\_shares](#input\_datacenter\_shares) | Which groups have access to the datacenter | <pre>list(object({<br>    group  = string<br>    edit   = optional(bool, false)<br>    share  = optional(bool, false)<br>  }))</pre> | `[]` | no |
 | <a name="input_routes_map"></a> [routes\_map](#input\_routes\_map) | map which links based on the lan id to a list in which the routes in form of an object ('network'='###' and 'gateway\_ip'='###') are saved | `any` | `{}` | no |
@@ -35,6 +36,7 @@ No modules.
 |------|-------------|
 | <a name="output_alb_target_lan_id"></a> [alb\_target\_lan\_id](#output\_alb\_target\_lan\_id) | n/a |
 | <a name="output_backend_crossconnect_id"></a> [backend\_crossconnect\_id](#output\_backend\_crossconnect\_id) | n/a |
+| <a name="output_custom_lans_id"></a> [custom\_lans\_id](#output\_custom\_lans\_id) | n/a |
 | <a name="output_datacenter_id"></a> [datacenter\_id](#output\_datacenter\_id) | n/a |
 | <a name="output_datacenter_location"></a> [datacenter\_location](#output\_datacenter\_location) | n/a |
 | <a name="output_datacenter_name"></a> [datacenter\_name](#output\_datacenter\_name) | n/a |
@@ -48,6 +50,7 @@ No modules.
 | <a name="output_lan_nlb_target"></a> [lan\_nlb\_target](#output\_lan\_nlb\_target) | n/a |
 | <a name="output_lan_postgres"></a> [lan\_postgres](#output\_lan\_postgres) | n/a |
 | <a name="output_lan_service"></a> [lan\_service](#output\_lan\_service) | n/a |
+| <a name="output_lans_custom"></a> [lans\_custom](#output\_lans\_custom) | n/a |
 | <a name="output_nat_lan_id"></a> [nat\_lan\_id](#output\_nat\_lan\_id) | n/a |
 | <a name="output_nfs_server_lan_id"></a> [nfs\_server\_lan\_id](#output\_nfs\_server\_lan\_id) | n/a |
 | <a name="output_nlb_target_lan_id"></a> [nlb\_target\_lan\_id](#output\_nlb\_target\_lan\_id) | n/a |
@@ -66,6 +69,7 @@ No modules.
 | [ionoscloud_datacenter.datacenter](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.3.6/docs/resources/datacenter) | resource |
 | [ionoscloud_lan.alb_target_lan](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.3.6/docs/resources/lan) | resource |
 | [ionoscloud_lan.backend_lan](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.3.6/docs/resources/lan) | resource |
+| [ionoscloud_lan.custom_lan](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.3.6/docs/resources/lan) | resource |
 | [ionoscloud_lan.frontend_lan](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.3.6/docs/resources/lan) | resource |
 | [ionoscloud_lan.nat_lan](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.3.6/docs/resources/lan) | resource |
 | [ionoscloud_lan.nfs_server_lan](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.3.6/docs/resources/lan) | resource |

--- a/modules/ionos-datacenter/locals.tf
+++ b/modules/ionos-datacenter/locals.tf
@@ -15,6 +15,7 @@ locals {
   service_crossconnect_shared_group_ids   = (length(var.crossconnect_shared_group_ids) > 0 && local.create_frontend_crossconnect == true) ? var.crossconnect_shared_group_ids : []
   routes_map                              = var.routes_map 
   create_postgres_lan                     = var.create_postgres_lan
+  custom_lans_to_create                   = var.custom_lans_to_create
   # this saves the service/backend/frontend lans as an object in a list
   # Example of an object:
   # > type({"id" = "id", "routes_list" = [{"network" = "10.0.0.0/24", gateway_ip="10.0.0.0"}]})
@@ -28,12 +29,13 @@ locals {
   #     ]),
   # })
   # if no routes_map is provided, a default value of [{}] is given (just empty), to comply with type requirements in further processing
-  lan_service = flatten([ for id in ionoscloud_lan.service_lan.*.id: { id = id, routes_list = [{}] }])
-  lan_backend = flatten([ for id in ionoscloud_lan.backend_lan.*.id: { id = id, routes_list = lookup(local.routes_map, id , [{}]) }])
-  lan_frontend = flatten([ for id in ionoscloud_lan.frontend_lan.*.id: { id = id, routes_list = lookup(local.routes_map, id , [{}]) }])
-  lan_nfs_server = flatten([ for id in ionoscloud_lan.nfs_server_lan.*.id: { id = id, routes_list = [{}] }])
-  lan_postgres = flatten([ for id in ionoscloud_lan.postgres_lan.*.id: { id = id, routes_list = [{}] }])
-  lan_alb_target = flatten([ for id in ionoscloud_lan.alb_target_lan.*.id: { id = id, routes_list =[{}] }])
-  lan_nlb_target = flatten([ for id in ionoscloud_lan.nlb_target_lan.*.id: { id = id, routes_list =[{}] }])
-  lan_nat = flatten([ for id in ionoscloud_lan.nat_lan.*.id: { id = id, routes_list = [{}] }])
+  lan_service     = flatten([ for id in ionoscloud_lan.service_lan.*.id: { id = id, routes_list = [{}] }])
+  lan_backend     = flatten([ for id in ionoscloud_lan.backend_lan.*.id: { id = id, routes_list = lookup(local.routes_map, id , [{}]) }])
+  lan_frontend    = flatten([ for id in ionoscloud_lan.frontend_lan.*.id: { id = id, routes_list = lookup(local.routes_map, id , [{}]) }])
+  lan_nfs_server  = flatten([ for id in ionoscloud_lan.nfs_server_lan.*.id: { id = id, routes_list = [{}] }])
+  lan_postgres    = flatten([ for id in ionoscloud_lan.postgres_lan.*.id: { id = id, routes_list = [{}] }])
+  lan_alb_target  = flatten([ for id in ionoscloud_lan.alb_target_lan.*.id: { id = id, routes_list =[{}] }])
+  lan_nlb_target  = flatten([ for id in ionoscloud_lan.nlb_target_lan.*.id: { id = id, routes_list =[{}] }])
+  lan_nat         = flatten([ for id in ionoscloud_lan.nat_lan.*.id: { id = id, routes_list = [{}] }])
+  lans_custom     = { for name, lan in ionoscloud_lan.custom_lan: name => { id = lan.id, routes_list = [{}] }}
 }

--- a/modules/ionos-datacenter/main.tf
+++ b/modules/ionos-datacenter/main.tf
@@ -118,3 +118,10 @@ resource "ionoscloud_lan" "nat_lan" {
   datacenter_id = ionoscloud_datacenter.datacenter.id
   public        = false
 }
+
+resource "ionoscloud_lan" "custom_lan" {
+  for_each      = local.custom_lans_to_create
+  name          = "${var.datacenter_name}-${each.value}"
+  datacenter_id = ionoscloud_datacenter.datacenter.id
+  public        = false
+}

--- a/modules/ionos-datacenter/output.tf
+++ b/modules/ionos-datacenter/output.tf
@@ -78,3 +78,11 @@ output "nat_lan_id" {
 output "lan_nat" {
   value = local.lan_nat
 }
+
+output "custom_lans_id" {
+  value = { for name, lan in ionoscloud_lan.custom_lan: name => lan.id }
+}
+
+output "lans_custom" {
+  value = local.lans_custom
+}

--- a/modules/ionos-datacenter/variables.tf
+++ b/modules/ionos-datacenter/variables.tf
@@ -102,3 +102,9 @@ variable "create_nat_lan" {
   description = "Specifies whether a private lan to connect a NAT gateway shall be created."
   default = false
 }
+
+variable "custom_lans_to_create" {
+  description = "Map of for private LANs to be created. The key is used for the output. The value is used for the name: <datacenter name>-<value>"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
# Description
Add option to create multiple LANs with provided names.
(Will be used to create instance specific LANs).
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
[OPS-6085](https://ticketsystem.dbildungscloud.de/browse/OPS-6085)
<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.