### PR TITLE
OPS-6704-mongodb-template-workaround

### DIFF
--- a/modules/ionos-mongodb-cluster/README.md
+++ b/modules/ionos-mongodb-cluster/README.md
@@ -5,6 +5,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_ionoscloud"></a> [ionoscloud](#provider\_ionoscloud) | 6.4.18 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 ## Modules
 
 | Name | Source | Version |
@@ -52,4 +53,5 @@
 | [ionoscloud_mongo_cluster.mongo_cluster](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.4.18/docs/resources/mongo_cluster) | resource |
 | [ionoscloud_mongo_user.initial_mongo_user](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.4.18/docs/resources/mongo_user) | resource |
 | [ionoscloud_mongo_template.mongo_template](https://registry.terraform.io/providers/ionos-cloud/ionoscloud/6.4.18/docs/data-sources/mongo_template) | data source |
+| [null_data_source.template_workaround](https://registry.terraform.io/providers/hashicorp/null/latest/docs/data-sources/data_source) | data source |
 <!-- END_TF_DOCS -->

--- a/modules/ionos-mongodb-cluster/data.tf
+++ b/modules/ionos-mongodb-cluster/data.tf
@@ -2,3 +2,14 @@ data "ionoscloud_mongo_template" "mongo_template" {
   count = var.resource_template == null ? 0 : 1
   name = var.resource_template
 }
+
+# Workaround
+# There's probably a bug in the IONOS Provider: The DataSource ionoscloud_mongo_template doesn't define id
+# as computed, leading to an inconsistent final plan (id is null instead of unknown in the initial plan)
+# This null_data_source is in between and the output is unknown in the initial plan, solving the problem.
+data "null_data_source" "template_workaround" {
+  inputs = {
+    mongo_template_id = var.resource_template == null ? null : data.ionoscloud_mongo_template.mongo_template[0].id
+  }
+  depends_on = [ data.ionoscloud_mongo_template.mongo_template ]
+}

--- a/modules/ionos-mongodb-cluster/main.tf
+++ b/modules/ionos-mongodb-cluster/main.tf
@@ -16,22 +16,13 @@ resource ionoscloud_mongo_cluster "mongo_cluster" {
     cidr_list     = local.cidrs
   }
 
-  template_id = terraform_data.template_id_workaround.output
+  template_id = data.null_data_source.template_workaround.outputs["mongo_template_id"]
   edition     = var.resource_template == null ? "enterprise" : null
 
   maintenance_window {
     day_of_the_week = var.maintenance_day
     time            = format("%02d:00:00", var.maintenance_hour)
   }
-}
-
-# Workaround
-# There's probably a bug in the IONOS Provider: The DataSource ionoscloud_mongo_template doesn't define id
-# as computed, leading to an inconsistent final plan (id is null instead of unknown in the initial plan)
-# This resource is in between and the output is unknown in the initial plan, solving the problem.
-resource "terraform_data" "template_id_workaround" {
-  input = var.resource_template == null ? null : data.ionoscloud_mongo_template.mongo_template[0].id
-  depends_on = [ data.ionoscloud_mongo_template.mongo_template ]
 }
 
 resource "ionoscloud_mongo_user" "initial_mongo_user" {

--- a/modules/ionos-mongodb-cluster/main.tf
+++ b/modules/ionos-mongodb-cluster/main.tf
@@ -16,13 +16,22 @@ resource ionoscloud_mongo_cluster "mongo_cluster" {
     cidr_list     = local.cidrs
   }
 
-  template_id = var.resource_template == null ? null : data.ionoscloud_mongo_template.mongo_template[0].id
+  template_id = terraform_data.template_id_workaround.output
   edition     = var.resource_template == null ? "enterprise" : null
 
   maintenance_window {
     day_of_the_week = var.maintenance_day
     time            = format("%02d:00:00", var.maintenance_hour)
   }
+}
+
+# Workaround
+# There's probably a bug in the IONOS Provider: The DataSource ionoscloud_mongo_template doesn't define id
+# as computed, leading to an inconsistent final plan (id is null instead of unknown in the initial plan)
+# This resource is in between and the output is unknown in the initial plan, solving the problem.
+resource "terraform_data" "template_id_workaround" {
+  input = var.resource_template == null ? null : data.ionoscloud_mongo_template.mongo_template[0].id
+  depends_on = [ data.ionoscloud_mongo_template.mongo_template ]
 }
 
 resource "ionoscloud_mongo_user" "initial_mongo_user" {


### PR DESCRIPTION
# Description
Workaround for a problem with the ionoscloud_mongo_template DataSource:
The id is null in the inital plan, but has the correct value when read later, resulting in a inconsistent final plan.
```
Error: Provider produced inconsistent final plan
When expanding the plan for
module.ionos_mongodb_cluster["cd"].ionoscloud_mongo_cluster.mongo_cluster to
include new values learned so far during apply, provider
"registry.terraform.io/ionos-cloud/ionoscloud" produced an invalid new value
for .template_id: was null, but now
cty.StringVal("6b78ea06-ee0e-4689-998c-fc9c46e781f6").
This is a bug in the provider, which should be reported in the provider's own
issue tracker.
```
The null_data_source resource "hides" the initial null, resulting in a consistent final plan.
```
  # module.ionos_mongodb_cluster["cd"].data.null_data_source.template_workaround will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "null_data_source" "template_workaround" {
      + has_computed_default = (known after apply)
      + id                   = (known after apply)
      + inputs               = {
          + "mongo_template_id" = null
        }
      + outputs              = (known after apply)
      + random               = (known after apply)
    }
```
<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.