### PR TITLE
OPS-7332 add protocol_version

### DIFF
--- a/modules/ionos-application-loadbalancer/main.tf
+++ b/modules/ionos-application-loadbalancer/main.tf
@@ -50,6 +50,7 @@ resource "ionoscloud_target_group" "k8s_node_pools" {
     name                      = "${module.conventions_coordinates.global_identifier}-k8s" 
     algorithm                 = "ROUND_ROBIN"
     protocol                  = "HTTP"  
+    protocol_version          = "HTTP1"
     dynamic "targets" {
       for_each = var.node_alb_lan_ips
       content { 


### PR DESCRIPTION
# Description

infra-terraform-modules needs new release. 
protocol_version should be optional by docs but is mandatory or failing if not exists (also linter showing syntax error when not set!)
https://registry.terraform.io/providers/ionos-cloud/ionoscloud/latest/docs/resources/target_group#protocol_version-1

<!--
  This is a template to add as many information as possible to the PR, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other PRs
[OPS-7332] https://ticketsystem.dbildungscloud.de/browse/OPS-7332
Update Terraformprovicer

<!--
Base links to copy
- https://github.com/dbildungsplattform/????/pull/????
- https://ticketsystem.dbildungscloud.de/browse/DBP-????

-->

## Notes

<!--
You may want to provide additional information:
    - References
    - Rollout
    - Structure/Design
    - Repercussions
-->


## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.